### PR TITLE
Add back-button fallback and fix scroll to top

### DIFF
--- a/b2w2/index.html
+++ b/b2w2/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/bw/index.html
+++ b/bw/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/core/minidex_v1b.js
+++ b/core/minidex_v1b.js
@@ -472,10 +472,10 @@ function showPokemon(id,form){
 	}
 
 	/* smooth scroll to top */
-	if(currentDistanceFromHome===0)
-		goToTop(true);
-	else
-		goToTop();
+//	if(currentDistanceFromHome===0)
+//		goToTop(true);
+//	else
+//		goToTop();
 }
 
 

--- a/dppt/index.html
+++ b/dppt/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/frlg/index.html
+++ b/frlg/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/gsc/index.html
+++ b/gsc/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/hgss/index.html
+++ b/hgss/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/letsgo/index.html
+++ b/letsgo/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/oras/index.html
+++ b/oras/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/rby/index.html
+++ b/rby/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/rse/index.html
+++ b/rse/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/sm/index.html
+++ b/sm/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/swsh/index.html
+++ b/swsh/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/usum/index.html
+++ b/usum/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>

--- a/xy/index.html
+++ b/xy/index.html
@@ -126,7 +126,7 @@
 
 	<div id="pokemon" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i class="sprite pokeball"></i><span id="pokemon-title"></span>
 		</div>
 		<!-- INFO -->
@@ -164,7 +164,7 @@
 
 	<div id="location" class="screen">
 		<div class="screen-title">
-			<i class="back-button sprite back clickable" onclick="forceGoToHome()"></i>
+			<a href="#"><i class="back-button sprite back clickable" onclick="forceGoToHome()"></i></a>
 			<i id="location-icon" class="sprite location"></i><span id="location-title"></span>
 		</div>
 		<div id="location-encounters"></div>


### PR DESCRIPTION
Two issues:
1) Clicking on the back button jumps to the top of the page, instead of staying at the position the user has scrolled to previously. Disabling the smooth scroll in minidex.js does the trick.
2) Certain Browsers like the Kiwi Browser don't like history manipulations. As a fallback, I added a link with href="#" to prevent the app from being unusable (back button does nothing) in such a scenario. Instead, the user gets back to the top of the page, regardless of which back button has been pressed. None of that applies to Browsers that worked fine in the first place, so those are unaffected by this change.